### PR TITLE
Add code blocks for command line examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,23 @@ These datasets can be generated from [/benchmarking](https://github.com/Bashivan
 - [Install graphiz on your machine](https://pygraphviz.github.io/documentation/stable/install.html)
 ### Poetry
 #### Install Poetry
-    curl -sSL https://install.python-poetry.org | python3 -
+
+```shell
+curl -sSL https://install.python-poetry.org | python3 -
+```
 
 ### Conda + Poetry
 #### Create conda python environment
-    conda create --name iwisdm python=3.11
+
+```shell
+conda create --name iwisdm python=3.11
+```
+
 #### Install packages
-    poetry install
+
+```shell
+poetry install
+```
 
 ### ShapeNet Subset 
 A large-scale repository of shapes represented by 3D CAD models of objects  [(Chang et. al. 2015)](https://arxiv.org/abs/1512.03012).

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -1,17 +1,26 @@
 # Benchmarking Run Parameters
 
 ### Single Frame Example
-    python create_bench.py --stim_dir='../data/shapenet_handpicked' --tasks_dir='./tasks/single_cat' --trials_dir='temp/single_cat'
-    --config_path='configs/single_frame_cat.json' --min_len=1 --max_len=1 --n_trials=100 --n_tasks=10 --features='cat' --min_joint_ops=0 --max_joint_ops=0 --force_balance
+
+
+```shell
+python create_bench.py --stim_dir='../data/shapenet_handpicked' --tasks_dir='./tasks/single_cat' --trials_dir='temp/single_cat' --config_path='configs/single_frame_cat.json' --min_len=1 --max_len=1 --n_trials=100 --n_tasks=10 --features='cat' --min_joint_ops=0 --max_joint_ops=0 --force_balance
+```
 
 ### Low Complexity Example:
-    python create_bench.py --stim_dir='../data/shapenet_handpicked' --tasks_dir='./tasks/low_all' --trials_dir='temp/low_all' 
-    --config_path='configs/low_complexity_all.json' --min_len=6 --max_len=6  --n_trials=100 --n_tasks=100 --features='all' --min_joint_ops=1 --max_joint_ops=1 --force_balance
+
+```shell
+python create_bench.py --stim_dir='../data/shapenet_handpicked' --tasks_dir='./tasks/low_all' --trials_dir='temp/low_all' --config_path='configs/low_complexity_all.json' --min_len=6 --max_len=6  --n_trials=100 --n_tasks=100 --features='all' --min_joint_ops=1 --max_joint_ops=1 --force_balance
+```
 
 ### Medium Complexity Example:
-    python create_bench.py --stim_dir='../data/shapenet_handpicked' --tasks_dir='./tasks/medium_all' --trials_dir='temp/medium_all' 
-    --config_path='configs/medium_complexity_all.json' --min_len=8 --max_len=8 --n_trials=100 --n_tasks=100 --features='all' --min_joint_ops=1 --max_joint_ops=1 --force_balance
+
+```shell
+python create_bench.py --stim_dir='../data/shapenet_handpicked' --tasks_dir='./tasks/medium_all' --trials_dir='temp/medium_all' --config_path='configs/medium_complexity_all.json' --min_len=8 --max_len=8 --n_trials=100 --n_tasks=100 --features='all' --min_joint_ops=1 --max_joint_ops=1 --force_balance
+```
 
 ### High Complexity Example:
-    python create_bench.py --stim_dir='../data/shapenet_handpicked' --tasks_dir='./tasks/high_all' --trials_dir='temp/high_all' 
-    --config_path='configs/high_complexity_all.json' --min_len=9 --max_len=9 --n_trials=100 --n_tasks=100 --features='all' --min_joint_ops=1 --max_joint_ops=2 --force_balance --non_bool_actions
+
+```shell
+python create_bench.py --stim_dir='../data/shapenet_handpicked' --tasks_dir='./tasks/high_all' --trials_dir='temp/high_all'  --config_path='configs/high_complexity_all.json' --min_len=9 --max_len=9 --n_trials=100 --n_tasks=100 --features='all' --min_joint_ops=1 --max_joint_ops=2 --force_balance --non_bool_actions
+```


### PR DESCRIPTION
Wrap command line instructions in code blocks for better readability and consistency with markdown formatting standards.